### PR TITLE
fix failing sort test

### DIFF
--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -291,7 +291,7 @@ class CollectionTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $output = $collection->sortByDesc('id')->all();
+        $output = $collection->sortByDesc('name')->all();
 
         $this->assertTrue($expected === $output);
     }


### PR DESCRIPTION
I'm not sure exactly what this failing test was checking for. I assume that the `sortByDesc` was supposed to be by `name` and then the compare should be true, vs. sorting using a key that doesn't exists.
