### PR TITLE
improve the filter function. improvement allows reject method support

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -198,12 +198,41 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate, JsonSeria
     /**
      * Run a filter over each of the items.
      *
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @return static
      */
-    public function filter(callable $callback)
+    public function filter(callable $callback = null)
     {
-        return new static(array_filter($this->items, $callback));
+        if ($callback) {
+            $return = [];
+            foreach ($this->items as $key => $value) {
+                if ($callback($value, $key)) {
+                    $return[$key] = $value;
+                }
+            }
+            return new static($return);
+        }
+
+        return new static(array_filter($this->items));
+    }
+
+    /**
+     * Create a collection of all elements that do not pass a given truth test.
+     *
+     * @param  callable|mixed  $callback
+     * @return static
+     */
+    public function reject($callback)
+    {
+        if (is_callable($callback)) {
+            return $this->filter(function ($value, $key) use ($callback) {
+                return ! $callback($value, $key);
+            });
+        }
+
+        return $this->filter(function ($item) use ($callback) {
+            return $item != $callback;
+        });
     }
 
     /**

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -481,6 +481,28 @@ class CollectionTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_reject_filter_a_collection()
+    {
+        $collection = new Collection([1, 2, 3, 4]);
+
+        $filtered = $collection->reject(function ($value, $key) {
+            return $value > 2;
+        });
+
+        $this->assertEquals([1, 2], $filtered->all());
+
+        $filtered2 = $collection->reject(3);
+
+        $expected = [
+            0 => 1,
+            1 => 2,
+            3 => 4,
+        ];
+
+        $this->assertEquals($expected, $filtered2->all());
+    }
+
+    /** @test */
     public function it_can_map_a_collection_using_a_function()
     {
         $collection = new Collection([


### PR DESCRIPTION
Stealing `filter` from https://github.com/illuminate/support/blob/master/Collection.php#L197

Allows support for `reject` as https://github.com/illuminate/support/blob/master/Collection.php#L717

All tests still pass
